### PR TITLE
PerformingContext null on first job run

### DIFF
--- a/Hangfire.Console.Extensions/HangfireExtensions.cs
+++ b/Hangfire.Console.Extensions/HangfireExtensions.cs
@@ -18,6 +18,8 @@ namespace Hangfire.Console.Extensions
             services.AddSingleton<IJobManager, JobManager>();
             services.AddTransient<IJobCancellationToken>(sp => sp.GetRequiredService<IPerformingContextAccessor>().Get().CancellationToken);
             services.AddTransient<PerformingContext>(sp => sp.GetRequiredService<IPerformingContextAccessor>().Get());
+            GlobalJobFilters.Filters.Add(new HangfireSubscriber());
+
             return services;
         }
     }

--- a/Hangfire.Console.Extensions/HangfireSubscriber.cs
+++ b/Hangfire.Console.Extensions/HangfireSubscriber.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using Hangfire.Common;
+using System;
 using System.Threading;
 using Hangfire.Server;
+using System.Collections.Generic;
 
 namespace Hangfire.Console.Extensions
 {
@@ -9,14 +11,7 @@ namespace Hangfire.Console.Extensions
     /// </summary>
     internal class HangfireSubscriber : IServerFilter
     {
-        private static readonly HangfireSubscriber instance;
         private static readonly AsyncLocal<PerformingContext> localStorage = new AsyncLocal<PerformingContext>();
-
-        static HangfireSubscriber()
-        {
-            instance = new HangfireSubscriber();
-            GlobalJobFilters.Filters.Add(instance);
-        }
 
         public static PerformingContext Value => localStorage.Value;
 


### PR DESCRIPTION
Using the Serilog package, there are some scenarios where the PerformingContext is returned as null when a job is first run, but then subsequent jobs log just fine.  It seems like this is because the HangfireSubscriber filter is being added after job execution begins.  Adding the HangfireSubscriber during ConfigureServices seems to resolve this issue.  Not sure why this behavior is different from the MEL implementation, I'm assuming there is a difference between Serilog and MEL startup.