### PR TITLE
Enable the use of Serilog LevelSwitches and restrictedToMinimumLevel

### DIFF
--- a/Hangfire.Console.Extensions.Serilog/HangfireSinkExtensions.cs
+++ b/Hangfire.Console.Extensions.Serilog/HangfireSinkExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Serilog;
 using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace Hangfire.Console.Extensions.Serilog
 {
@@ -15,9 +17,11 @@ namespace Hangfire.Console.Extensions.Serilog
 
         public static LoggerConfiguration Hangfire(
                   this LoggerSinkConfiguration loggerConfiguration,
-                  IFormatProvider formatProvider = null)
+                  IFormatProvider formatProvider = null,
+                  LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+                  LoggingLevelSwitch levelSwitch = null)
         {
-            return loggerConfiguration.Sink(new HangfireSink(formatProvider));
+            return loggerConfiguration.Sink(new HangfireSink(formatProvider), restrictedToMinimumLevel, levelSwitch);
         }
     }
 }

--- a/SampleWithSerilog/appsettings.json
+++ b/SampleWithSerilog/appsettings.json
@@ -30,7 +30,10 @@
         }
       },
       {
-        "Name": "Hangfire"
+        "Name": "Hangfire",
+        "Args": {
+          "restrictedToMinimumLevel": "Warning"
+        }
       }
     ]
   },


### PR DESCRIPTION
Most Serilog sinks allow you to specify an arg "restrictedToMinimumLevel", and, alternatively, allow you to specify a "LevelSwitch". These settings configure the minimum level that a log event must have. If it has a lower level, the log event is not emitted to the sink.

This pull request adds that ability to the `HangfireSink`.