### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/SampleWithSerilog/SampleWithSerilog.csproj
+++ b/SampleWithSerilog/SampleWithSerilog.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.10" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@AnderssonPeter, I found an issue in the SampleWithSerilog.csproj:

Packages Hangfire.AspNetCore v1.7.10, Serilog.AspNetCore v3.2.0,Serilog.Sinks.Async v1.4.0, Serilog.Sinks.Console v3.1.1 and Serilog.Sinks.File v4.1.0 transitively introduce 101 dependencies into Hangfire.Console.Extensions’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Hangfire-Console-Extensions.html)), while Hangfire.AspNetCore v1.7.24, Serilog.AspNetCore v3.4.0,Serilog.Sinks.Async v1.5.0, Serilog.Sinks.Console v4.0.0 and Serilog.Sinks.File v5.0.0 can only introduce 71 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Hangfire-Console-Extensions_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose