### PR TITLE
take last jobDetails history as currentState

### DIFF
--- a/Hangfire.Console.Extensions/JobManager.cs
+++ b/Hangfire.Console.Extensions/JobManager.cs
@@ -48,7 +48,7 @@ namespace Hangfire.Console.Extensions
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var jobDetails = monitoringApi.JobDetails(jobId);
-                string currentState = jobDetails.History[0].StateName;
+                var currentState = jobDetails.History.LastOrDefault()?.StateName;
                 if (!runningStates.Contains(currentState))
                 {
                     if (currentState == SucceededState.StateName)


### PR DESCRIPTION
`jobDetails.History[0]StateName` will always return `Enqueued` causing it never to return so its a infinite loop or till `cancellationToken.ThrowIfCancellationRequested` fires
#12 