### PR TITLE
filter logs being sent to hangfire console

### DIFF
--- a/Hangfire.Console.Extensions/HangfireLoggerProvider.cs
+++ b/Hangfire.Console.Extensions/HangfireLoggerProvider.cs
@@ -2,6 +2,7 @@
 
 namespace Hangfire.Console.Extensions
 {
+    [ProviderAlias("Hangfire")]
     public class HangfireLoggerProvider : ILoggerProvider
     {
         private readonly IPerformingContextAccessor performingContextAccesor;

--- a/Sample/appsettings.Development.json
+++ b/Sample/appsettings.Development.json
@@ -1,4 +1,11 @@
 {
+  "Hangfire": {
+    "LogLevel": {
+      "Default": "None",
+      "Sample.ContinuationJob": "Information",
+      "Sample.SampleJob": "Information"
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/Sample/appsettings.json
+++ b/Sample/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Hangfire": {
+    "LogLevel": {
+      "Default": "None",
+      "Sample.ContinuationJob": "Information",
+      "Sample.SampleJob": "Information"
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
in your current implementation, all logs are being sent to the hangfire console (e.g EF Core). With my changes, it is possible to set log level filter for categories.